### PR TITLE
extended themeing engine to allow for patching

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4122,6 +4122,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-json-patch": {
+      "version": "3.0.0-1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
+      "integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -36,6 +36,7 @@
     "compare-versions": "~3.1.0",
     "copy-webpack-plugin": "^5.1.1",
     "core-js": "~2.5.4",
+    "fast-json-patch": "^3.0.0-1",
     "font-awesome": "^4.7.0",
     "localize-router": "https://github.com/andrewwhitehead/localize-router/releases/download/v2.0.0-RC.2/localize-router-2.0.0-RC.2.tgz",
     "localize-router-http-loader": "~1.0.2",


### PR DESCRIPTION
- added new functionality to allow for theme developers to override via JSON patching angular and other top level (themes folder) .json files

**Documentation**

In order to activate the theme overrides, you much create a .patches folder at the root of your theme folder. There is a small formatting convention to that the new functionality expects in order to read this correctly, and it is as follows;
```
2020-02-12-113055.angular.json
--- timestamp ---|--filename-- 
```
The timestamp portion helps for the sorting since patching can be sequence sensitive and the last part is filename to override. There is not directory crawling ability (that is safely tested) so you can only give this feature file names that are directly below the themes.

P.S: You may theoretically be able patch lower files by adding escaped directory separators but this was not in scope for the this release so mileage may vary.

The patching leverages the ```fast-json-path``` module so please refer to that npm package for how to format and create patches [https://www.npmjs.com/package/fast-json-patch].

Signed-off-by: mario.bonito <mario.bonito@canada.ca>