### PR TITLE
Solr Indexing Thread Updates

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,6 +123,8 @@ services:
       - TRACE_EVENTS=${TRACE_EVENTS}
       - TRACE_PROOF_EVENTS=${TRACE_PROOF_EVENTS}
       - TRACE_TARGET=${TRACE_TARGET}
+      - RTI_ABORT_ON_ERRORS=${RTI_ABORT_ON_ERRORS}
+      - RTI_RAISE_ERRORS=${RTI_RAISE_ERRORS}
     volumes:
       - ../server/vcr-server/vcr_server:/home/indy/vcr_server
       - ../server/vcr-server/subscriptions:/home/indy/subscriptions

--- a/server/vcr-server/api/v2/utils.py
+++ b/server/vcr-server/api/v2/utils.py
@@ -110,7 +110,7 @@ def solr_counts():
     last_month_q = total_q.filter(create_timestamp__gte=last_month)
     try:
         return {
-            "total": total_q.count(),
+            "total_indexed_items": total_q.count(),
             "active": latest_q.count(),
             "registrations": registrations_q.count(),
             "last_month": last_month_q.count(),

--- a/server/vcr-server/api/v2/views/rest.py
+++ b/server/vcr-server/api/v2/views/rest.py
@@ -284,7 +284,15 @@ class TopicViewSet(ReadOnlyModelViewSet):
                                     or None,
                                     "type": related_topic.get_local_name().type or None,
                                 } if related_topic.get_local_name() else {},
-                                "remote_name": related_topic.get_remote_name() or None,
+                                "remote_name": {
+                                    "id": related_topic.get_remote_name().id,
+                                    "text": related_topic.get_remote_name().text or None,
+                                    "language": related_topic.get_remote_name().language
+                                    or None,
+                                    "credential_id": related_topic.get_remote_name().credential_id
+                                    or None,
+                                    "type": related_topic.get_remote_name().type or None,
+                                } if related_topic.get_remote_name() else {},
                             } if related_topic else {}
                             for related_topic in credential.related_topics.all()
                         ],

--- a/server/vcr-server/vcr_server/utils/solrqueue.py
+++ b/server/vcr-server/vcr_server/utils/solrqueue.py
@@ -11,9 +11,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 # this will kill the vcr-api process
-ABORT_ON_ERRORS = True
+ABORT_ON_ERRORS = os.getenv("RTI_ABORT_ON_ERRORS", "TRUE").upper()
+ABORT_ON_ERRORS = ABORT_ON_ERRORS == "TRUE"
 # this will re-raise errors, which will kill the indexing thread
-RAISE_ERRORS = False
+RAISE_ERRORS = os.getenv("RTI_RAISE_ERRORS", "FALSE").upper()
+RAISE_ERRORS = RAISE_ERRORS == "TRUE"
 # if both of the above are false, indexing errors will be ignored
 
 class SolrQueue:


### PR DESCRIPTION
Update info returned in the /api/quickload endpoint to list counts for all indexed items

Update indexing thread to ignore, raise or abort on errors

ignore = errors are ignored and processing continues
raise = indexing thread aborts but vcr-api continues to process inbound credentials
abort = vcr-api process is aborted if there is an indexing error
