### PR TITLE
Add batching support to real-time solr indexing

### DIFF
--- a/server/vcr-server/vcr_server/utils/solrqueue.py
+++ b/server/vcr-server/vcr_server/utils/solrqueue.py
@@ -11,12 +11,21 @@ LOGGER = logging.getLogger(__name__)
 
 
 # this will kill the vcr-api process
-ABORT_ON_ERRORS = os.getenv("RTI_ABORT_ON_ERRORS", "TRUE").upper()
-ABORT_ON_ERRORS = ABORT_ON_ERRORS == "TRUE"
+RTI_ABORT_ON_ERRORS = os.getenv("RTI_ABORT_ON_ERRORS", "TRUE").upper()
+ABORT_ON_ERRORS = RTI_ABORT_ON_ERRORS == "TRUE"
 # this will re-raise errors, which will kill the indexing thread
-RAISE_ERRORS = os.getenv("RTI_RAISE_ERRORS", "FALSE").upper()
-RAISE_ERRORS = RAISE_ERRORS == "TRUE"
+RTI_RAISE_ERRORS = os.getenv("RTI_RAISE_ERRORS", "FALSE").upper()
+RAISE_ERRORS = RTI_RAISE_ERRORS == "TRUE"
 # if both of the above are false, indexing errors will be ignored
+
+# number of seconds to wait when solr queue is empty before retry
+RTI_WAIT_TIME = os.getenv("RTI_WAIT_TIME", "5")
+WAIT_TIME = int(RTI_WAIT_TIME)
+
+# max number of items to trigger an update to the solr index
+RTI_MAX_SOLR_BATCH = os.getenv("RTI_MAX_SOLR_BATCH", "25")
+MAX_SOLR_BATCH = int(RTI_MAX_SOLR_BATCH)
+
 
 class SolrQueue:
     is_active = False
@@ -109,20 +118,26 @@ class SolrQueue:
     def _run(self):
         LOGGER.info("Running Solr queue ...")
         while True:
-            self._trigger.wait(5)
+            LOGGER.debug("Waiting [%d] ...", WAIT_TIME)
+            self._trigger.wait(WAIT_TIME)
             self._drain()
             if self._stop.is_set():
                 LOGGER.info("Finished running Solr queue ...")
                 return
 
+
+    def index_type(self, index_cls, delete, using):
+        """String representing the index class type."""
+        if not index_cls:
+            return None
+        return ("delete" if delete == 1 else "update") + "::" + str(index_cls) + "::" + str(using)
+
+
     def _drain(self):
-        # LOGGER.debug("Indexing Solr queue items ...")
+        LOGGER.debug("Indexing Solr queue items ...")
         global RAISE_ERRORS
         global ABORT_ON_ERRORS
-        last_index = None
-        last_using = None
-        last_del = 0
-        last_ids = set()
+        last_ids = {}
         try:
             self.is_active = True
             while True:
@@ -130,35 +145,44 @@ class SolrQueue:
                     index_cls, using, ids, delete = self._queue.get_nowait()
                     LOGGER.debug("Pop items off the Solr queue for indexing; Class: %s, Using: %s, Delete: %s, Instances: %s", index_cls, using, delete, ids)
                 except Empty:
-                    # LOGGER.debug("Solr queue is empty ...")
+                    LOGGER.debug("Solr queue is empty ...")
                     index_cls = None
-                if last_index and last_index == index_cls and last_using == using and last_del == delete:
-                    LOGGER.debug("Updating list of ids ...")
-                    last_ids.update(ids)
-                else:
-                    if last_index:
+                    delete = 0
+                    using = None
+                index_cls_type = self.index_type(index_cls, delete, using)
+                if index_cls:
+                    LOGGER.debug("Updating list of ids for [%s]..." % index_cls_type)
+                    if not index_cls_type in last_ids:
+                        last_ids[index_cls_type] = {
+                            "index_cls": index_cls,
+                            "delete": delete,
+                            "using": using,
+                            "ids": set(),
+                        }
+                    last_ids[index_cls_type]["ids"].update(ids)
+                for attr, val in last_ids.items():
+                    if (not index_cls) or MAX_SOLR_BATCH <= len(val["ids"]):
+                        LOGGER.debug("Processing %s items for [%s]", len(val["ids"]), attr)
                         try:
-                            if last_del:
-                                self.remove(last_index, last_using, last_ids)
+                            if val["delete"] == 1:
+                                self.remove(val["index_cls"], val["using"], val["ids"])
                             else:
-                                self.update(last_index, last_using, last_ids)
+                                self.update(val["index_cls"], val["using"], val["ids"])
+                            last_ids[attr]["ids"] = set()
                         except:
                             LOGGER.exception("An unexpected exception was encountered while processing items from the Solr queue.", exc_info=True)
                             LOGGER.info("Requeueing items for later processing ...")
                             try:
-                                self._queue.put( (last_index, last_using, last_ids, last_del) )
+                                self._queue.put( (val["index_cls"], val["using"], val["ids"], val["delete"]) )
                             except Full:
-                                LOGGER.error("Can't requeue items to the Solr queue because it is full; %s", last_ids)
+                                LOGGER.error("Can't requeue items to the Solr queue because it is full; %s", val["ids"])
                                 raise
+                            raise
 
-                    if not index_cls:
-                        # LOGGER.debug("Done indexing items from Solr queue ...")
-                        break
+                if not index_cls:
+                    LOGGER.debug("Done indexing items from Solr queue ...")
+                    break
 
-                    last_index = index_cls
-                    last_using = using
-                    last_del = delete
-                    last_ids = set(ids)
         except Exception as e:
             LOGGER.error("Error processing real-time index queue: %s", str(e))
             if ABORT_ON_ERRORS:


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Batch solr updates, includes 2 new environment params to configure batching:

RTI_WAIT_TIME = number of seconds to wait once solr queue is empty (default 5)
RTI_MAX_SOLR_BATCH = post update to solr once this number of indexes is receives (default 25)
