### PR TITLE
Add missing dependency

### DIFF
--- a/server/vcr-server/requirements.txt
+++ b/server/vcr-server/requirements.txt
@@ -45,3 +45,4 @@ asgiref~=3.1.2
 django-rest-hooks==1.5.0
 drf-nested-routers
 celery~=4.3.0
+vine~=1.3.0


### PR DESCRIPTION
`vine` used to be pulled in transitively by `celery`, but that is not the case anymore.