### PR TITLE
New api to query topics by attribute value

### DIFF
--- a/server/vcr-server/api/v2/views/rest.py
+++ b/server/vcr-server/api/v2/views/rest.py
@@ -317,6 +317,10 @@ class TopicViewSet(ReadOnlyModelViewSet):
         if not type or not source_id:
             raise Http404()
 
+        # map type to a schema name, if an "old style" type is used
+        if settings.CRED_TYPE_SYNONYMS and type.lower() in settings.CRED_TYPE_SYNONYMS:
+            type = settings.CRED_TYPE_SYNONYMS[type.lower()]
+
         queryset = self.filter_queryset(self.get_queryset())
         obj = get_object_or_404(queryset, type=type, source_id=source_id)
 

--- a/server/vcr-server/api/v3/urls.py
+++ b/server/vcr-server/api/v3/urls.py
@@ -34,7 +34,10 @@ router.register(r"credentialtype", rest.CredentialTypeViewSet)
 router.register(r"credential", rest.CredentialViewSet)
 # router.register(r"topic", rest.TopicViewSet)
 
-api_views = [path("topic/<type>/<source_id>", rest.TopicView.as_view())]
+api_views = [
+    path("search/topic/attribute/<attribute_query>", rest.TopicAttributeView.as_view()),
+    path("topic/<type>/<source_id>", rest.TopicView.as_view()),
+]
 
 # router.register(r"topic_relationship", rest.TopicRelationshipViewSet)
 

--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -173,6 +173,10 @@ SWAGGER_SETTINGS = {
     ],
 }
 
+CRED_TYPE_SYNONYMS = {
+    "registration": "registration.registries.ca"
+}
+
 LOGIN_URL = "rest_framework:login"
 LOGOUT_URL = "rest_framework:logout"
 


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Add a new api to query topic by attribute value - this can be any attribute/value of any credential "owned" by the topic.

`/api/v3/search/topic/attribute/<attribute_query>`, where `<attribute_query>` is of the format `attribute_name::value`

For example:  `/api/v3/search/topic/attribute/business_number::123456789`

This does a straight database query, vs using solr, and does not require the attribute to be flagged as a "category" for solr.

Rationale:  
- solr manages "facets" for all "categories", and setting a unique attribute (all companies have unique BN's) will lead to excessive overhead in solr managing all these facets of one for almost every company
- we have api's that return facets for topics and credentials, and adding BN as a category/facet will bulk up the output from these api's excessively
- it will be overly complex trying to incorporate the attribute search into the name search api (name is mandatory; category is already used for entity_type, etc) so the attribute search should be separated anyways, so simpler to add a new api endpoint that try to add additional complexity to the existing one
- search by category value for topic currently doesn't work unless the attribute is on the "foundational credential" (i.e. the registration) - searching for the BN on a BN credential doesn't work under a topic search

