### PR TITLE
Make the API startup delay optional.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -125,6 +125,7 @@ services:
       - RTI_ABORT_ON_ERRORS=${RTI_ABORT_ON_ERRORS}
       - RTI_RAISE_ERRORS=${RTI_RAISE_ERRORS}
       - RANDOM_ERRORS=${RANDOM_ERRORS}
+      - STARTUP_DELAY=${STARTUP_DELAY}
     volumes:
       - ../server/vcr-server/vcr_server:/home/indy/vcr_server
       - ../server/vcr-server/subscriptions:/home/indy/subscriptions

--- a/docker/manage
+++ b/docker/manage
@@ -454,6 +454,7 @@ configureEnvironment() {
   export CORE_NAME="credential_registry"
 
   # vcr-api
+  export STARTUP_DELAY=${STARTUP_DELAY:-15}
   export APP_FILE=app-vonx.py
   export APP_CONFIG=${APP_CONFIG:-}
   # export APP_MODULE=api_indy.vcr_anchor.boot:init_app

--- a/server/vcr-server/app-vonx.py
+++ b/server/vcr-server/app-vonx.py
@@ -19,7 +19,7 @@ parser = argparse.ArgumentParser(description="aiohttp server example")
 parser.add_argument("--host", default=os.getenv("HTTP_HOST"))
 parser.add_argument("-p", "--port", default=os.getenv("HTTP_PORT"))
 parser.add_argument("-s", "--socket", default=os.getenv("SOCKET_PATH"))
-parser.add_argument("-d", "--delay", default=15)
+parser.add_argument("-d", "--delay", default=os.getenv("STARTUP_DELAY"))
 
 
 if __name__ == "__main__":
@@ -29,6 +29,8 @@ if __name__ == "__main__":
     if args.delay:
         print(">>> Short pause", args.delay)
         time.sleep(int(args.delay))
+    else:
+        print(">>> Start-up delay disabled ...")
 
     django.setup()
 


### PR DESCRIPTION
- For deployment environments there should be no delay so the services start up as quickly as possible.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>