### PR TITLE
Add default logging configuration

### DIFF
--- a/server/db/config/postgresql-cfg/dbconnections.conf
+++ b/server/db/config/postgresql-cfg/dbconnections.conf
@@ -1,26 +1,6 @@
 #------------------------------------------------------------------------------
-# CONNECTIONS AND AUTHENTICATION
+# CONNECTIONS
 #------------------------------------------------------------------------------
 
 # - Connection Settings -
-
 max_connections = 300
-
-# logging_collector = on
-# log_statement = all
-# log_destination = stderr
-
-# log_connections = on
-# log_disconnections = on
-# log_duration = on
-# log_min_duration_statement = 100
-
-# log_lock_waits = on
-# deadlock_timeout = 100
-
-shared_preload_libraries=pg_stat_statements
-
-# synchronous_commit = off
-
-# min_wal_size = 1GB
-# max_wal_size = 16GB

--- a/server/db/config/postgresql-cfg/logging.conf
+++ b/server/db/config/postgresql-cfg/logging.conf
@@ -1,0 +1,146 @@
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - libraries required for logging -
+# Make sure this is only defined once in the merged config
+shared_preload_libraries=pg_stat_statements
+
+# - Where to Log -
+
+#log_destination = 'stderr'             # Valid values are combinations of
+                                        # stderr, csvlog, syslog, and eventlog,
+                                        # depending on platform.  csvlog
+                                        # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector = on                  # Enable capturing of stderr and csvlog
+                                        # into log files. Required to be on for
+                                        # csvlogs.
+                                        # (change requires restart)
+
+# These are only used if logging_collector is on:
+#log_directory = 'log'                  # directory where log files are written,
+                                        # can be absolute or relative to PGDATA
+log_filename = 'postgresql-%a.log'      # log file name pattern,
+                                        # can include strftime() escapes
+#log_file_mode = 0600                   # creation mode for log files,
+                                        # begin with 0 to use octal notation
+log_truncate_on_rotation = on           # If on, an existing log file with the
+                                        # same name as the new log file will be
+                                        # truncated rather than appended to.
+                                        # But such truncation only occurs on
+                                        # time-driven rotation, not on restarts
+                                        # or size-driven rotation.  Default is
+                                        # off, meaning append to existing files
+                                        # in all cases.
+log_rotation_age = 1d                   # Automatic rotation of logfiles will
+                                        # happen after that time.  0 disables.
+log_rotation_size = 0                   # Automatic rotation of logfiles will
+                                        # happen after that much log output.
+                                        # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+#syslog_sequence_numbers = on
+#syslog_split_messages = on
+
+# This is only relevant when logging to eventlog (win32):
+# (change requires restart)
+#event_source = 'PostgreSQL'
+
+# - When to Log -
+
+#client_min_messages = notice           # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   log
+                                        #   notice
+                                        #   warning
+                                        #   error
+
+#log_min_messages = warning             # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic
+
+#log_min_error_statement = error        # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic (effectively off)
+
+#log_min_duration_statement = -1        # -1 is disabled, 0 logs all statements
+                                        # and their durations, > 0 logs only
+                                        # statements running at least this number
+                                        # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = off
+#log_error_verbosity = default          # terse, default, or verbose messages
+#log_hostname = off
+#log_line_prefix = '%m [%p] '           # special values:
+                                        #   %a = application name
+                                        #   %u = user name
+                                        #   %d = database name
+                                        #   %r = remote host and port
+                                        #   %h = remote host
+                                        #   %p = process ID
+                                        #   %t = timestamp without milliseconds
+                                        #   %m = timestamp with milliseconds
+                                        #   %n = timestamp with milliseconds (as a Unix epoch)
+                                        #   %i = command tag
+                                        #   %e = SQL state
+                                        #   %c = session ID
+                                        #   %l = session line number
+                                        #   %s = session start timestamp
+                                        #   %v = virtual transaction ID
+                                        #   %x = transaction ID (0 if none)
+                                        #   %q = stop here in non-session
+                                        #        processes
+                                        #   %% = '%'
+                                        # e.g. '<%u%%%d> '
+#log_lock_waits = off                   # log lock waits >= deadlock_timeout
+#log_statement = 'none'                 # none, ddl, mod, all
+#log_replication_commands = off
+#log_temp_files = -1                    # log temporary files equal or larger
+                                        # than the specified size in kilobytes;
+                                        # -1 disables, 0 logs all temp files
+log_timezone = 'UCT'
+
+
+# - Process Title -
+
+#cluster_name = ''                      # added to process titles if nonempty
+                                        # (change requires restart)
+#update_process_title = on


### PR DESCRIPTION
- These will end up overriding the settings in the main PostgreSQL conf file.
- Sets the configuration up to allow a config map to be overlaid on the file to allow for runtime configuration.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>