### PR TITLE
Fix typo in api/v3/views/rest.py

### DIFF
--- a/server/vcr-server/api/v3/views/rest.py
+++ b/server/vcr-server/api/v3/views/rest.py
@@ -243,7 +243,7 @@ class CredentialViewSet(RetriveOnlyModelViewSet):
                 },
             }
             if "presentation" in presentation_state:
-                result["result"]["presentaiton"] = presentation_state["presentation"]
+                result["result"]["presentation"] = presentation_state["presentation"]
 
         if result is None:
             result = {"success": False, "results": "Presentation request response not available."}


### PR DESCRIPTION
Fixes typo that would prevent the code in the UI verify logic (see [here](https://github.com/bcgov/aries-vcr/blob/3eb479244c0bdddfdfc7790a9e2f5e8abb19a514/client/src/app/data-types.ts#L252-L257) ) to work.