### PR TITLE
Resolves errors with Swagger pages not loading in development

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -425,7 +425,7 @@ configureEnvironment() {
   export STI_SCRIPTS_PATH=${STI_SCRIPTS_PATH:-/usr/libexec/s2i}
   export RUST_LOG=${RUST_LOG:-warn}
   export RUST_BACKTRACE=${RUST_BACKTRACE:-full}
-  export DEBUG=${DEBUG:-false}
+  export DEBUG=${DEBUG:-"True"}
 
   # vcr-db
   export POSTGRESQL_DATABASE="THE_ORG_BOOK"

--- a/server/vcr-server/manage.py
+++ b/server/vcr-server/manage.py
@@ -12,7 +12,7 @@ def main():
 
     from django.conf import settings
 
-    if settings.DEBUG:
+    if settings.DJANGO_DEBUG:
         if os.environ.get("RUN_MAIN") or os.environ.get("WERKZEUG_RUN_MAIN"):
             import debugpy
 

--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -47,7 +47,8 @@ SECRET_KEY = os.getenv(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = parse_bool(os.getenv("DJANGO_DEBUG", "False"))
+DEBUG = parse_bool(os.getenv("DEBUG", "True"))
+DJANGO_DEBUG = parse_bool(os.getenv("DJANGO_DEBUG", "False"))
 
 DEMO_SITE = parse_bool(os.getenv("DEMO_SITE", "False"))
 

--- a/server/vcr-server/wsgi.py
+++ b/server/vcr-server/wsgi.py
@@ -22,13 +22,6 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vcr_server.settings")
 
-# Visual Studio Code debugging. Only works if django is run with --noreload
-# if os.environ.get("DJANGO_DEBUG", False):  # You can use django.conf settings.DEBUG
-#     import ptvsd
-
-#     ptvsd.enable_attach(address=("0.0.0.0", 5678))
-#     # ptvsd.wait_for_attach()
-
 application = get_wsgi_application()
 
 # Apply WSGI middleware here.


### PR DESCRIPTION
Issue introduced by #591 and #602 

The `DEBUG` variable was previously enabled by default in development modes. This flag automatically handles static files in Django for displaying Swagger pages. The variable was also linked to the `DJANGO_DEBUG` variable. The latter was repurposed to allow for remote debugging of Django in development and disabled by default resulting in issues with static files and displaying of Swagger pages.

Changelog:
* `DJANGO_DEBUG` variable has been unlinked from the `DEBUG` variable.
  * Django debugging can now be enabled separately by setting `DJANGO_DEBUG` when staring the docker containers
* `DEBUG` is re-enabled by default in development mode again