### PR TITLE
Excludes names in formatted Topics

### DIFF
--- a/server/vcr-server/api/v2/serializers/search.py
+++ b/server/vcr-server/api/v2/serializers/search.py
@@ -159,7 +159,11 @@ class CustomTopicSerializer(TopicSerializer):
     def get_names(self, obj):
         names = Name.objects.filter(
             credential__topic=obj, credential__latest=True, credential__revoked=False
-        ).order_by("credential__inactive")
+        ).filter(
+            type__in=("entity_name_assumed", "entity_name")
+        ).order_by(
+            "credential__inactive"
+        )
         serializer = CustomNameSerializer(instance=names, many=True)
         return serializer.data
 

--- a/server/vcr-server/api/v3/views/rest.py
+++ b/server/vcr-server/api/v3/views/rest.py
@@ -27,7 +27,6 @@ from api.v2.models.TopicRelationship import TopicRelationship
 from api.v2.serializers.rest import (
     CredentialSerializer,
     CredentialTypeSerializer,
-    ExpandedCredentialSerializer,
     ExpandedCredentialSetSerializer,
     IssuerSerializer,
     SchemaSerializer,
@@ -37,8 +36,6 @@ from api.v2.serializers.rest import (
 
 from .viewsets import RetriveOnlyModelViewSet
 from ..mixins import MultipleFieldLookupMixin
-
-from api.v2.serializers.search import CustomTopicSerializer
 
 logger = getLogger(__name__)
 

--- a/server/vcr-server/vcr_server/custom_settings_bcgov.py
+++ b/server/vcr-server/vcr_server/custom_settings_bcgov.py
@@ -8,36 +8,6 @@ from rest_framework.decorators import action
 LOGGER = logging.getLogger(__name__)
 
 
-# @action(detail=True, url_path="related_to")
-# def list_related_to(self, request, pk=None):
-#    # We load most at runtime because ORM isn't loaded at setup time
-#    from django.shortcuts import get_object_or_404
-#    from api.v2.views.rest import CustomTopicSerializer
-#    from api.v2.models.Topic import Topic
-#    from rest_framework.response import Response
-
-#    parent_queryset = Topic.objects.all()
-#    item = get_object_or_404(parent_queryset, pk=pk)
-#    queryset = item.get_active_related_to()
-#    serializer = CustomTopicSerializer(queryset, many=True)
-#    return Response(serializer.data)
-
-
-# @action(detail=True, url_path="related_from")
-# def list_related_from(self, request, pk=None):
-#    # Secondary imports do not incur a cost
-#    from django.shortcuts import get_object_or_404
-#    from api.v2.views.rest import CustomTopicSerializer
-#    from api.v2.models.Topic import Topic
-#    from rest_framework.response import Response
-
-#    parent_queryset = Topic.objects.all()
-#    item = get_object_or_404(parent_queryset, pk=pk)
-#    queryset = item.get_active_related_from()
-#    serializer = CustomTopicSerializer(queryset, many=True)
-#    return Response(serializer.data)
-
-
 @action(detail=True, url_path="related_to_relations")
 def list_related_to_relations(self, request, pk=None):
     # We load most at runtime because ORM isn't loaded at setup time
@@ -116,10 +86,6 @@ def list_related_to_relations(self, request, pk=None):
         for topic_relationship in topic_relationships
     ]
 
-    # serializer = CustomTopicRelationshipSerializer(
-    #     parent_queryset, many=True, relationship_type="to"
-    # )
-
     return Response(data)
 
 
@@ -171,7 +137,6 @@ CUSTOMIZATIONS = {
         },
     },
     "views": {
-        # "TopicViewSet": {"includeMethods": [list_related_to, list_related_from]},
         "TopicRelationshipViewSet": {
             "includeMethods": [list_related_to_relations, list_related_from_relations]
         },


### PR DESCRIPTION
Fixes #616

Affects the following endpoints:
* `v2/topic/{id}/formatted`
* `v2/topic/ident/{type}/{source_id}/formatted`

Change log:

* Names returned in the results will exclude any names that are not of the type `entity_name` or `entity_name_asssumed`.