### PR TITLE
Fixes Swagger API loading issue when `DEBUG` is set to `false`

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,3 +1,15 @@
+# This configuration file overrides the settings in 
+# `./docker-compose.dev.yml` when `DEBUG` is set
+# to `true`.
+#
+# For example: The settings here allow for hot module
+# reloading of the API server when code is changed.
+#
+# These settings are not applied when `DEBUG` mode is 
+# set to `false`. Settings that are not listed here but
+# are in the  main `./docker-compose.yml` will remain
+# even if the ovveride is applied.
+#
 version: "3"
 services:
   vcr-api:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 # This configuration file overrides the settings in 
-# `./docker-compose.dev.yml` when `DEBUG` is set
+# `./docker-compose.yml` when `DEBUG` is set
 # to `true`.
 #
 # For example: The settings here allow for hot module

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  vcr-api:
+    volumes:
+      - ../server/vcr-server/vcr_server:/home/indy/vcr_server
+      - ../server/vcr-server/subscriptions:/home/indy/subscriptions
+      - ../server/vcr-server/agent_webhooks:/home/indy/agent_webhooks
+      - ../server/vcr-server/api:/home/indy/api
+      - vcr-wallet:/home/indy/.indy_client/wallet

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,16 +54,24 @@ services:
   # vcr-api
   #-------------------------------------------------
   # The API performs the migrations on the database
-  # and updates the indexes in Solr.  Therefore
+  # and updates the indexes in Solr. Therefore
   # it needs to come up after the database and
   # and Solr services have had time to fully
   # initialize.
-  #
   #
   # We are using a simple sleep command to do this
   # for the moment; refer to the `command` section
   # of the configuration for details.  It would be
   # nice to implement a more deterministic solution.
+  #
+  # When `DEBUG` is set to `true` the override
+  # configurations defined in `./docker-compose.dev.yml`
+  # are applied and will take effect. See the override
+  # config file for more details.
+  # 
+  # Due to the way configurations are applied, it is
+  # recommended to rebuild containers to disable `DEBUG`
+  # mode if it was previously enabled.
   #
   vcr-api:
     image: vcr-api

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -127,7 +127,6 @@ services:
       - RANDOM_ERRORS=${RANDOM_ERRORS}
       - STARTUP_DELAY=${STARTUP_DELAY}
     volumes:
-      - ../server/vcr-server/vcr_server:/home/indy/vcr_server
       - ../server/vcr-server/subscriptions:/home/indy/subscriptions
       - ../server/vcr-server/agent_webhooks:/home/indy/agent_webhooks
       - ../server/vcr-server/api:/home/indy/api

--- a/docker/manage
+++ b/docker/manage
@@ -522,6 +522,12 @@ configureEnvironment() {
   if [ "${TRACE_EVENTS}" = "true" ]; then
     AGENT_TRACE_MODE="--trace"
   fi
+
+  unset composeOptions
+  if [ $DEBUG = true  ]; then
+    # Override the vcr-api volume settings; add volume mount to enable hot reloading.
+    export composeOptions="-f docker-compose.yml -f docker-compose.dev.yml"
+  fi
 }
 
 getInputParams() {
@@ -668,12 +674,7 @@ case "${COMMAND}" in
   start|up)
     _startupParams=$(getStartupParams --force-recreate $@)
     configureEnvironment "$@"
-    if [ $DEBUG = true  ];
-    then
-      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --scale vcr-worker=2 -d ${_startupParams} 
-    else
-      docker-compose up --scale vcr-worker=2 -d ${_startupParams} 
-    fi
+    docker-compose ${composeOptions} up --scale vcr-worker=2 -d ${_startupParams}
     docker-compose logs -f
     ;;
   scale|upscale)
@@ -683,24 +684,14 @@ case "${COMMAND}" in
     echo "NOTE make sure you have removed the port mapping in docker-compose.yml for vcr-api and vcr-agent!!!"
     echo "Press any key to continue or <CRTL-C> to abort"
     read anykey
-    if [ $DEBUG = true ];
-    then
-      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams}
-    else
-      docker-compose up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams}
-    fi
+    docker-compose ${composeOptions} up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams}
     docker-compose logs -f
     ;;
   restart)
     _startupParams=$(getStartupParams $@)
     configureEnvironment "$@"
     docker-compose stop ${_startupParams}
-    if [ $DEBUG = true ];
-    then
-      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d ${_startupParams}
-    else 
-      docker-compose up -d ${_startupParams}
-    fi
+    docker-compose ${composeOptions} up -d ${_startupParams}
     ;;
   logs)
     configureEnvironment "$@"

--- a/docker/manage
+++ b/docker/manage
@@ -668,7 +668,12 @@ case "${COMMAND}" in
   start|up)
     _startupParams=$(getStartupParams --force-recreate $@)
     configureEnvironment "$@"
-    docker-compose up --scale vcr-worker=2 -d ${_startupParams} 
+    if [ $DEBUG = true  ];
+    then
+      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --scale vcr-worker=2 -d ${_startupParams} 
+    else
+      docker-compose up --scale vcr-worker=2 -d ${_startupParams} 
+    fi
     docker-compose logs -f
     ;;
   scale|upscale)
@@ -678,14 +683,24 @@ case "${COMMAND}" in
     echo "NOTE make sure you have removed the port mapping in docker-compose.yml for vcr-api and vcr-agent!!!"
     echo "Press any key to continue or <CRTL-C> to abort"
     read anykey
-    docker-compose up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams} 
+    if [ $DEBUG = true ];
+    then
+      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams}
+    else
+      docker-compose up --scale vcr-worker=2 --scale vcr-api=6 --scale vcr-agent=5 -d ${_startupParams}
+    fi
     docker-compose logs -f
     ;;
   restart)
     _startupParams=$(getStartupParams $@)
     configureEnvironment "$@"
     docker-compose stop ${_startupParams}
-    docker-compose up -d ${_startupParams}
+    if [ $DEBUG = true ];
+    then
+      docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d ${_startupParams}
+    else 
+      docker-compose up -d ${_startupParams}
+    fi
     ;;
   logs)
     configureEnvironment "$@"

--- a/server/vcr-server/vcr_server/urls.py
+++ b/server/vcr-server/vcr_server/urls.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import AllowAny
 from django.conf import settings
 from django.urls import include, path
 from django.views.generic import RedirectView
+from django.conf.urls.static import static
 
 from . import views
 
@@ -40,4 +41,5 @@ api_patterns = [
     path("api/v4/", include("api.v4.urls", namespace="v4"), name="api-v4"),
 ]
 
-urlpatterns = base_patterns + hook_patterns + api_patterns
+urlpatterns = base_patterns + hook_patterns + api_patterns + \
+    static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Fixes issue #623 with local deployments when the `DEBUG` variable is set to `false`.

Issue identified:
* A `docker-compose` volume was configured to allow for hot reloading in development mode. In development mode, static files are not served directly from the file system but are handled by the development server.
* When `DEBUG` mode is not set static files are served directly from the file system and since these were being overwritten by the volume mount, a 500 Server Error resulted when trying to load the API.

Fix:
* Removes the volume mount when `DEBUG` mode is disabled (as it assumes the end user is not developing or debugging the API). When `DEBUG` is set, a special `docker-compose` development override includes the volume mount to allow for code hot reloading.