### PR TITLE
Add reindex signal to credential, remove from topic

### DIFF
--- a/server/vcr-server/api/v2/models/Credential.py
+++ b/server/vcr-server/api/v2/models/Credential.py
@@ -7,6 +7,8 @@ from api.v2.utils import local_name, remote_name
 
 
 class Credential(Auditable):
+    reindex_related = ["topic"]
+
     topic = models.ForeignKey(
         "Topic", related_name="credentials", on_delete=models.CASCADE
     )

--- a/server/vcr-server/api/v2/models/Topic.py
+++ b/server/vcr-server/api/v2/models/Topic.py
@@ -11,7 +11,6 @@ from api.v2.utils import local_name, remote_name
 
 
 class Topic(Auditable):
-    reindex_related = ["foundational_credential"]
 
     source_id = models.TextField()
     type = models.TextField()


### PR DESCRIPTION
Fix for #638

* Adds `related_index` to Credential model that will trigger an index update on its parent Topic.
* Removes current `related_index` on Topic model that will trigger an update on its Foundational Credential. 

Given that there is a mutual reference between Topics and Credentials and the recursive nature of the Real Time Signal Processor, index triggers can only be specified on either Topic or Credential. The logic behind this change is that Topics are based off Credentials and thus changes in Credentials should trigger an index update on Topics rather than the reverse.

Point of discussion: Will this have any influence on the order of add operations to the db?