### PR TITLE
Increase default pagination size

### DIFF
--- a/server/vcr-server/vcr_server/pagination.py
+++ b/server/vcr-server/vcr_server/pagination.py
@@ -4,14 +4,15 @@ from collections import OrderedDict
 from django.core.paginator import Paginator
 from rest_framework.pagination import BasePagination, PageNumberPagination
 from rest_framework.response import Response
+from django.conf import settings
 
 LOGGER = logging.getLogger(__name__)
 
 
 class EnhancedPageNumberPagination(PageNumberPagination):
-    page_size = 10
+    page_size = settings.REST_FRAMEWORK["PAGE_SIZE"]
     page_size_query_param = "page_size"
-    max_page_size = 20
+    max_page_size = settings.REST_FRAMEWORK["MAX_PAGE_SIZE"]
 
     def get_paginated_response(self, data):
         return Response(

--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -158,7 +158,8 @@ AUTH_USER_MODEL = "api_v2.User"
 REST_FRAMEWORK = {
     # "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_PAGINATION_CLASS": "vcr_server.pagination.EnhancedPageNumberPagination",
-    "PAGE_SIZE": 10,
+    "PAGE_SIZE": 100,
+    "MAX_PAGE_SIZE": 200,
     "DEFAULT_AUTHENTICATION_CLASSES": authentication.defaults(),
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly"


### PR DESCRIPTION
Use pagination size from settings.py rather than hard-coded values.

This is a workaround to prevent issues such as [this](https://github.com/bcgov/orgbook-bc-client/issues/28), where a limited number of paginated results might prevent the correct retrieval of all entries even with low number of returned objects.

For the specific `/credentialtype` endpoint (and possibly others).

Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>