### PR TITLE
added issuer back into credential_type

### DIFF
--- a/server/vcr-server/api/v4/serializers/rest/credential.py
+++ b/server/vcr-server/api/v4/serializers/rest/credential.py
@@ -29,7 +29,8 @@ class CredentialAttributeSerializer(AttributeSerializer):
         read_only_fields = fields
 
 
-class CredentialTypeSchemaSerializer(ModelSerializer):
+class CredentialTypeIssuerSerializer(ModelSerializer):
+    issuer = IssuerSerializer()
     has_logo = BooleanField(source="get_has_logo", read_only=True)
 
     class Meta:
@@ -44,12 +45,11 @@ class CredentialTypeSchemaSerializer(ModelSerializer):
             "visible_fields",
             "highlighted_attributes",
             "credential_title",
-            "issuer",
         )
 
 
 class SchemaSerializer(ModelSerializer):
-    credential_types = CredentialTypeSchemaSerializer(many=True)
+    credential_types = CredentialTypeIssuerSerializer(many=True)
 
     class Meta:
         model = Schema
@@ -97,4 +97,4 @@ class CredentialSerializer(ModelSerializer):
 
 
 class RestSerializer(CredentialSerializer):
-    credential_type = CredentialTypeSchemaSerializer()
+    credential_type = CredentialTypeIssuerSerializer()


### PR DESCRIPTION
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>

added issuer foreign key back into credential type.
Issuer object is needed by orgbook v2 in order to properly display credentials