### PR TITLE
spit credential serializer into two

### DIFF
--- a/server/vcr-server/api/v4/serializers/rest/credential.py
+++ b/server/vcr-server/api/v4/serializers/rest/credential.py
@@ -29,8 +29,7 @@ class CredentialAttributeSerializer(AttributeSerializer):
         read_only_fields = fields
 
 
-class CredentialTypeIssuerSerializer(ModelSerializer):
-    issuer = IssuerSerializer()
+class CredentialTypeSchemaSerializer(ModelSerializer):
     has_logo = BooleanField(source="get_has_logo", read_only=True)
 
     class Meta:
@@ -45,11 +44,28 @@ class CredentialTypeIssuerSerializer(ModelSerializer):
             "visible_fields",
             "highlighted_attributes",
             "credential_title",
+            "issuer"
+        )
+
+class CredentialTypeExtendedSerializer(ModelSerializer):
+    issuer = IssuerSerializer()
+    has_logo = BooleanField(source="get_has_logo", read_only=True)
+
+    class Meta:
+        model = CredentialType
+        depth = 1
+        exclude = (
+            "category_labels",
+            "claim_descriptions",
+            "claim_labels",
+            "logo_b64",
+            "processor_config",
+            "visible_fields",
         )
 
 
 class SchemaSerializer(ModelSerializer):
-    credential_types = CredentialTypeIssuerSerializer(many=True)
+    credential_types = CredentialTypeSchemaSerializer(many=True)
 
     class Meta:
         model = Schema
@@ -97,4 +113,4 @@ class CredentialSerializer(ModelSerializer):
 
 
 class RestSerializer(CredentialSerializer):
-    credential_type = CredentialTypeIssuerSerializer()
+    credential_type = CredentialTypeExtendedSerializer()


### PR DESCRIPTION
Moved v4 CredentialTypeSerializer into CredentialTypeSchemaSerializer and CredentialTypeExtandedSerializer. `CredentialTypeSchemaSerializer` only contains the information needed to be displayed on the `/api/v4/schemas` endpoint while `CredentialTypeExtandedSerializer` contains the issuer, highlighted attributes, etc. This allows us to limit the amount of unneeded information displayed at the schemas endpoint while still preserving the new orgbook functionality.
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>