### PR TITLE
Fix: Update delete credential call

### DIFF
--- a/server/vcr-server/agent_webhooks/management/commands/delete_topic.py
+++ b/server/vcr-server/agent_webhooks/management/commands/delete_topic.py
@@ -33,8 +33,8 @@ class Command(BaseCommand):
                     for credential in topic.credentials.all():
                         self.stdout.write(" ... " + credential.credential_id + " ...")
                         try:
-                            response = requests.post(
-                                f"{settings.AGENT_ADMIN_URL}/credential/{credential.credential_id}/remove",
+                            response = requests.delete(
+                                f"{settings.AGENT_ADMIN_URL}/credential/{credential.credential_id}",
                                 headers=settings.ADMIN_REQUEST_HEADERS,
                             )
                             response.raise_for_status()


### PR DESCRIPTION
- The agent admin API signature for deleting credentials has changed.  These breaking changes were made in v0.5.5:
  - https://github.com/hyperledger/aries-cloudagent-python/commit/2b556c683c6ee34d582c21e2b3fad0d770a472f4
  - https://github.com/hyperledger/aries-cloudagent-python/commit/f1610cdc82d91ad655b641bddebc040a37676775

Signed-off-by: Wade Barnes <wade@neoterictech.ca>