### PR TITLE
Change argument name to match expected value

### DIFF
--- a/server/vcr-server/api/v2/utils.py
+++ b/server/vcr-server/api/v2/utils.py
@@ -276,7 +276,7 @@ def call_agent_with_retry(agent_url, post_method=True, payload=None, headers=Non
                 503,  # Service unavailable
                 504   # Gateway timeout
             ],
-            method_whitelist=['HEAD', 'TRACE', 'GET',
+            allowed_methods=['HEAD', 'TRACE', 'GET',
                               'POST', 'PUT', 'OPTIONS', 'DELETE'],
             read=0,
             redirect=0,


### PR DESCRIPTION
- The name of the argument was changed in urllib3.util.Retry.

Resolves #751 