### PR TITLE
Update API terms of service to reference Access Only data license

### DIFF
--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -295,7 +295,7 @@ API_METADATA = {
     "organizations and businesses will also begin to issue digital records through "
     "OrgBook BC. For example, permits and licenses issued by various government services.",
     "terms": {"url": "https://www2.gov.bc.ca/gov/content/data/open-data"},
-    "contact": {"email": "bcdevexchange@gov.bc.ca"},
+    "contact": {"email": "DItrust@gov.bc.ca"},
     "license": {
         "name": "Access Only License - British Columbia",
         "url": "https://bcgov.github.io/data-publication/pages/faq.html#data-publication-licensing-options---open-dataaccess-only",

--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -297,8 +297,8 @@ API_METADATA = {
     "terms": {"url": "https://www2.gov.bc.ca/gov/content/data/open-data"},
     "contact": {"email": "bcdevexchange@gov.bc.ca"},
     "license": {
-        "name": "Open Government License - British Columbia",
-        "url": "https://www2.gov.bc.ca/gov/content/data/open-data/api-terms-of-use-for-ogl-information",
+        "name": "Access Only License - British Columbia",
+        "url": "https://bcgov.github.io/data-publication/pages/faq.html#data-publication-licensing-options---open-dataaccess-only",
     },
 }
 


### PR DESCRIPTION
The data license currently referenced is not applicable, and was updated to reference the "Access Only" data license instead.