### PR TITLE
Remove terms of service swagger link, license is covered by licensing terms.

### DIFF
--- a/server/vcr-server/api/v2/urls.py
+++ b/server/vcr-server/api/v2/urls.py
@@ -19,7 +19,6 @@ schema_view = get_schema_view(
         title=API_METADATA["title"],
         description=API_METADATA["description"],
         default_version="v2",
-        terms_of_service=API_METADATA["terms"]["url"],
         contact=openapi.Contact(**API_METADATA["contact"]),
         license=openapi.License(**API_METADATA["license"]),
     ),

--- a/server/vcr-server/api/v3/urls.py
+++ b/server/vcr-server/api/v3/urls.py
@@ -16,7 +16,6 @@ schema_view = get_schema_view(
         title=API_METADATA["title"],
         default_version="v3",
         description=API_METADATA["description"],
-        terms_of_service=API_METADATA["terms"]["url"],
         contact=openapi.Contact(**API_METADATA["contact"]),
         license=openapi.License(**API_METADATA["license"]),
     ),

--- a/server/vcr-server/api/v4/urls.py
+++ b/server/vcr-server/api/v4/urls.py
@@ -25,7 +25,6 @@ schema_view = get_schema_view(
         title=API_METADATA["title"],
         default_version="v4",
         description=API_METADATA["description"],
-        terms_of_service=API_METADATA["terms"]["url"],
         contact=openapi.Contact(**API_METADATA["contact"]),
         license=openapi.License(**API_METADATA["license"]),
     ),

--- a/server/vcr-server/subscriptions/urls.py
+++ b/server/vcr-server/subscriptions/urls.py
@@ -24,7 +24,6 @@ schema_view = get_schema_view(
         title=API_METADATA["title"],
         description=API_METADATA["description"],
         default_version="v2",
-        terms_of_service=API_METADATA["terms"]["url"],
         contact=openapi.Contact(**API_METADATA["contact"]),
         license=openapi.License(**API_METADATA["license"]),
     ),

--- a/server/vcr-server/vcr_server/settings.py
+++ b/server/vcr-server/vcr_server/settings.py
@@ -294,7 +294,6 @@ API_METADATA = {
     "businesses in the Province of British Columbia. Over time, other government "
     "organizations and businesses will also begin to issue digital records through "
     "OrgBook BC. For example, permits and licenses issued by various government services.",
-    "terms": {"url": "https://www2.gov.bc.ca/gov/content/data/open-data"},
     "contact": {"email": "DItrust@gov.bc.ca"},
     "license": {
         "name": "Access Only License - British Columbia",


### PR DESCRIPTION
The Swagger doc listed both Terms of Service and License blocks, however we only have one document (linked under the license block) that can be used. Since both items are optional, the Terms of Service were removed in favour of the license block.