### PR TITLE
refactor: debugpy is configured by environment variable

### DIFF
--- a/docker/docker-compose-debug.yml
+++ b/docker/docker-compose-debug.yml
@@ -1,7 +1,10 @@
-version: '3'
+version: "3"
 services:
   vcr-api:
-    command: ["sh", "-c", "pip install debugpy -t /tmp && python ./manage.py migrate && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 ./manage.py runserver 0.0.0.0:8080"]
+    environment:
+      - DEBUGPY=${DEBUGPY}
+    command: >
+      sh -c "python ./manage.py migrate && if [ ! -z $DEBUGPY ]; then pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 ./manage.py runserver 0.0.0.0:8080; else python ./manage.py runserver 0.0.0.0:8080; fi"
     volumes:
       - ../server/vcr-server/vcr_server:/opt/app-root/src/vcr_server
       - ../server/vcr-server/subscriptions:/opt/app-root/src/subscriptions


### PR DESCRIPTION
In debug mode the application waits on the user to attach a debugpy session. This may not be ideal in all scenarios. This PR adds the ability to configure whether to install and attach a to a debugpy session or to just continue with development.